### PR TITLE
Fix otherGangNames

### DIFF
--- a/scripts/gangManager.js.js
+++ b/scripts/gangManager.js.js
@@ -109,8 +109,9 @@ export async function main(ns)
 	var otherGangNames = [];
 	for(var gangName in otherGangs)
 	{
-		otherGangNames.push(gangName);
-		//ns.tprint(gangName);
+		if (gangName != myGang.faction) {
+			otherGangNames.push(gangName);
+		}
 	}
 	
     while(true)


### PR DESCRIPTION
Inexplicably, getOtherGangInformation() also includes your gang's information. So, the getChanceToWinClash() loop later on always had one gang with a 0.5 chance to win: you. You're always equally matched with yourself. So, unless you were passing it a 0.5 combat chance, the script would always disable clashing, no matter what.

This fixes that!