### PR TITLE
memberInfo not having eq/aug array

### DIFF
--- a/scripts/gangManager.js.js
+++ b/scripts/gangManager.js.js
@@ -150,6 +150,8 @@ export async function main(ns)
 			var hadAll = true;
 		
             memInfo = ns.gang.getMemberInformation(m);
+			if(memInfo.equipment == undefined) memInfo.equipment = [];
+			if(memInfo.augmentations == undefined) memInfo.augmentations = [];	
 			
 			ns.gang.setMemberTask(m, unassignedTask);
 			


### PR DESCRIPTION
If a member does not have augmentations/equipment, the arrays will be undefined and throw an error when ran an .includes on
this checks for undefined and sets it to an empty array